### PR TITLE
feat: add data-driven scooter pages

### DIFF
--- a/app/api/scooters/[id]/route.ts
+++ b/app/api/scooters/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { scooters } from '@/data/scooters'
+
+interface Params {
+  params: { id: string }
+}
+
+export async function GET(_req: NextRequest, { params }: Params) {
+  const scooter = scooters.find(s => s.id === params.id)
+  if (!scooter) {
+    return NextResponse.json({ error: 'Scooter not found' }, { status: 404 })
+  }
+  return NextResponse.json({ scooter })
+}

--- a/app/api/scooters/route.ts
+++ b/app/api/scooters/route.ts
@@ -1,96 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-
-interface Scooter {
-  id: string
-  make: string
-  model: string
-  year: number
-  price: number
-  location: string
-  images: string[]
-  features: {
-    seats: number
-    transmission: string
-    fuel: string
-    doors: number
-  }
-  host: {
-    name: string
-    rating: number
-    trips: number
-  }
-  rating: number
-  reviews: number
-}
-
-const mockScooters: Scooter[] = [
-  {
-    id: '1',
-    make: 'Vespa',
-    model: 'Primavera',
-    year: 2023,
-    price: 89,
-    location: 'San Francisco, CA',
-    images: ['/api/placeholder/300/200'],
-    features: {
-      seats: 5,
-      transmission: 'Automatic',
-      fuel: 'Electric',
-      doors: 4
-    },
-    host: {
-      name: 'Alex Chen',
-      rating: 4.9,
-      trips: 312
-    },
-    rating: 4.9,
-    reviews: 127
-  },
-  {
-    id: '2',
-    make: 'Honda',
-    model: 'PCX',
-    year: 2022,
-    price: 120,
-    location: 'Los Angeles, CA',
-    images: ['/api/placeholder/300/200'],
-    features: {
-      seats: 7,
-      transmission: 'Automatic',
-      fuel: 'Gasoline',
-      doors: 4
-    },
-    host: {
-      name: 'Sarah Miller',
-      rating: 4.8,
-      trips: 156
-    },
-    rating: 4.8,
-    reviews: 89
-  },
-  {
-    id: '3',
-    make: 'Yamaha',
-    model: 'AeroX',
-    year: 2021,
-    price: 45,
-    location: 'New York, NY',
-    images: ['/api/placeholder/300/200'],
-    features: {
-      seats: 5,
-      transmission: 'Automatic',
-      fuel: 'Gasoline',
-      doors: 4
-    },
-    host: {
-      name: 'Mike Johnson',
-      rating: 4.7,
-      trips: 89
-    },
-    rating: 4.7,
-    reviews: 65
-  }
-]
+import { scooters, Scooter } from '@/data/scooters'
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams
@@ -101,7 +10,7 @@ export async function GET(request: NextRequest) {
   const seats = searchParams.get('seats')
   const fuel = searchParams.get('fuel')
 
-  let filteredScooters = mockScooters
+  let filteredScooters = scooters
 
   if (location) {
     filteredScooters = filteredScooters.filter(scooter => 
@@ -155,18 +64,26 @@ export async function POST(request: NextRequest) {
       location,
       images: ['/api/placeholder/300/200'],
       features: {
-        seats: features.seats || 5,
-        transmission: features.transmission || 'Automatic',
-        fuel: features.fuel || 'Gasoline',
-        doors: features.doors || 4
+        seats: features?.seats || 1,
+        transmission: features?.transmission || 'Automatic',
+        fuel: features?.fuel || 'Gasoline',
+        weightCapacity: features?.weightCapacity || 300,
+        batteryType: features?.batteryType || 'Lithium-Ion',
+        range: features?.range || 40,
+        category: features?.category || 'Standard'
       },
       host: {
         name: 'Current User',
+        avatar: '/api/placeholder/48/48',
         rating: 5.0,
         trips: 0
       },
       rating: 0,
-      reviews: 0
+      reviews: 0,
+      trips: 0,
+      description: '',
+      guidelines: [],
+      extras: []
     }
 
     return NextResponse.json({ scooter: newScooter }, { status: 201 })

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,66 +1,29 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { MagnifyingGlassIcon, MapPinIcon, CalendarDaysIcon, UserGroupIcon, StarIcon, ShieldCheckIcon, ClockIcon, HeartIcon } from '@heroicons/react/24/outline'
+import { useRouter } from 'next/navigation'
+import { MagnifyingGlassIcon, MapPinIcon, CalendarDaysIcon, UserGroupIcon, StarIcon, ShieldCheckIcon, ClockIcon, HeartIcon, CheckCircleIcon } from '@heroicons/react/24/outline'
+import type { Scooter } from '@/data/scooters'
 
 export default function Home() {
   const [searchLocation, setSearchLocation] = useState('')
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
+  const [featuredScooters, setFeaturedScooters] = useState<Scooter[]>([])
+  const router = useRouter()
 
-  const featuredScooters = [
-    {
-      id: 1,
-      make: 'Vespa',
-      model: 'Primavera',
-      year: 2023,
-      price: 89,
-      rating: 4.9,
-      trips: 124,
-      image: '/api/placeholder/300/200',
-      location: 'Los Angeles, CA'
-    },
-    {
-      id: 2,
-      make: 'Honda',
-      model: 'PCX',
-      year: 2023,
-      price: 129,
-      rating: 4.8,
-      trips: 89,
-      image: '/api/placeholder/300/200',
-      location: 'San Francisco, CA'
-    },
-    {
-      id: 3,
-      make: 'Yamaha',
-      model: 'AeroX',
-      year: 2022,
-      price: 45,
-      rating: 4.7,
-      trips: 256,
-      image: '/api/placeholder/300/200',
-      location: 'Miami, FL'
-    },
-    {
-      id: 4,
-      make: 'Piaggio',
-      model: 'Liberty',
-      year: 2023,
-      price: 299,
-      rating: 5.0,
-      trips: 45,
-      image: '/api/placeholder/300/200',
-      location: 'New York, NY'
-    }
-  ]
+  useEffect(() => {
+    fetch('/api/scooters')
+      .then(res => res.json())
+      .then(data => setFeaturedScooters(data.scooters.slice(0, 4)))
+      .catch(() => setFeaturedScooters([]))
+  }, [])
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
-    // Navigate to search results
-    window.location.href = `/search?location=${searchLocation}&start=${startDate}&end=${endDate}`
+    router.push(`/search?location=${searchLocation}&start=${startDate}&end=${endDate}`)
   }
 
   return (
@@ -150,6 +113,41 @@ export default function Home() {
         </div>
       </div>
 
+      {/* How It Works */}
+      <div className="py-16">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="text-center">
+            <h2 className="text-3xl font-bold text-gray-900">How Scoovio works</h2>
+          </div>
+
+          <div className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-3">
+            <div className="text-center">
+              <div className="flex items-center justify-center mx-auto h-12 w-12 rounded-full bg-scoovio-600 text-white">
+                <MagnifyingGlassIcon className="h-6 w-6" />
+              </div>
+              <h3 className="mt-4 text-lg font-medium text-gray-900">Search</h3>
+              <p className="mt-2 text-base text-gray-600">Find scooters near your destination.</p>
+            </div>
+
+            <div className="text-center">
+              <div className="flex items-center justify-center mx-auto h-12 w-12 rounded-full bg-scoovio-600 text-white">
+                <CalendarDaysIcon className="h-6 w-6" />
+              </div>
+              <h3 className="mt-4 text-lg font-medium text-gray-900">Book</h3>
+              <p className="mt-2 text-base text-gray-600">Choose dates and reserve in seconds.</p>
+            </div>
+
+            <div className="text-center">
+              <div className="flex items-center justify-center mx-auto h-12 w-12 rounded-full bg-scoovio-600 text-white">
+                <CheckCircleIcon className="h-6 w-6" />
+              </div>
+              <h3 className="mt-4 text-lg font-medium text-gray-900">Ride</h3>
+              <p className="mt-2 text-base text-gray-600">Meet your host and enjoy the ride.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
       {/* Featured Scooters */}
       <div className="bg-gray-50 py-16">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -163,7 +161,7 @@ export default function Home() {
               <div key={scooter.id} className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow">
                 <div className="relative">
                   <Image
-                    src={scooter.image}
+                    src={scooter.images[0]}
                     alt={`${scooter.make} ${scooter.model}`}
                     width={300}
                     height={200}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -5,26 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import Image from 'next/image'
 import Link from 'next/link'
 import { MagnifyingGlassIcon, MapPinIcon, CalendarDaysIcon, StarIcon, HeartIcon, FunnelIcon } from '@heroicons/react/24/outline'
-
-interface Scooter {
-  id: number
-  make: string
-  model: string
-  year: number
-  price: number
-  rating: number
-  trips: number
-  image: string
-  location: string
-  transmission: string
-  seats: number
-  fuel: string
-  host: {
-    name: string
-    rating: number
-    trips: number
-  }
-}
+import type { Scooter } from '@/data/scooters'
 
 export default function SearchPage() {
   const searchParams = useSearchParams()
@@ -39,112 +20,25 @@ export default function SearchPage() {
   })
 
   useEffect(() => {
-    // Simulate API call with mock data
-    const mockScooters: Scooter[] = [
-      {
-        id: 1,
-        make: 'Vespa',
-              model: 'Primavera',
-        year: 2023,
-        price: 89,
-        rating: 4.9,
-        trips: 124,
-        image: '/api/placeholder/400/300',
-        location: 'Los Angeles, CA',
-        transmission: 'Automatic',
-        seats: 5,
-        fuel: 'Electric',
-        host: { name: 'Alex M.', rating: 4.9, trips: 200 }
-      },
-      {
-        id: 2,
-        make: 'Honda',
-              model: 'PCX',
-        year: 2023,
-        price: 129,
-        rating: 4.8,
-        trips: 89,
-        image: '/api/placeholder/400/300',
-        location: 'San Francisco, CA',
-        transmission: 'Automatic',
-        seats: 7,
-        fuel: 'Gas',
-        host: { name: 'Sarah K.', rating: 4.8, trips: 150 }
-      },
-      {
-        id: 3,
-        make: 'Yamaha',
-              model: 'AeroX',
-        year: 2022,
-        price: 45,
-        rating: 4.7,
-        trips: 256,
-        image: '/api/placeholder/400/300',
-        location: 'Miami, FL',
-        transmission: 'Automatic',
-        seats: 5,
-        fuel: 'Gas',
-        host: { name: 'Mike R.', rating: 4.7, trips: 300 }
-      },
-      {
-        id: 4,
-        make: 'Piaggio',
-              model: 'Liberty',
-        year: 2023,
-        price: 299,
-        rating: 5.0,
-        trips: 45,
-        image: '/api/placeholder/400/300',
-        location: 'New York, NY',
-        transmission: 'Automatic',
-        seats: 4,
-        fuel: 'Gas',
-        host: { name: 'Emma L.', rating: 5.0, trips: 100 }
-      },
-      {
-        id: 5,
-        make: 'Kymco',
-              model: 'Like',
-        year: 2023,
-        price: 55,
-        rating: 4.6,
-        trips: 178,
-        image: '/api/placeholder/400/300',
-        location: 'Chicago, IL',
-        transmission: 'Automatic',
-        seats: 5,
-        fuel: 'Hybrid',
-        host: { name: 'David P.', rating: 4.6, trips: 250 }
-      },
-      {
-        id: 6,
-        make: 'SYM',
-              model: 'Fiddle',
-        year: 2023,
-        price: 85,
-        rating: 4.8,
-        trips: 92,
-        image: '/api/placeholder/400/300',
-        location: 'Denver, CO',
-        transmission: 'Manual',
-        seats: 5,
-        fuel: 'Gas',
-        host: { name: 'Lisa T.', rating: 4.8, trips: 120 }
-      }
-    ]
-    
-    setTimeout(() => {
-      setScooters(mockScooters)
-      setLoading(false)
-    }, 1000)
-  }, [])
+    const location = searchParams.get('location') || ''
+    const params = new URLSearchParams()
+    if (location) params.set('location', location)
 
-  const filteredScooters = scooters.filter(scooter => 
-    scooter.price >= filters.priceMin && 
+    setLoading(true)
+    fetch(`/api/scooters?${params.toString()}`)
+      .then(res => res.json())
+      .then(data => {
+        setScooters(data.scooters)
+        setLoading(false)
+      })
+  }, [searchParams])
+
+  const filteredScooters = scooters.filter(scooter =>
+    scooter.price >= filters.priceMin &&
     scooter.price <= filters.priceMax &&
-    (filters.transmission === 'all' || scooter.transmission === filters.transmission) &&
-    (filters.seats === 0 || scooter.seats >= filters.seats) &&
-    (filters.fuel === 'all' || scooter.fuel === filters.fuel)
+    (filters.transmission === 'all' || scooter.features.transmission === filters.transmission) &&
+    (filters.seats === 0 || scooter.features.seats >= filters.seats) &&
+    (filters.fuel === 'all' || scooter.features.fuel === filters.fuel)
   )
 
   return (
@@ -285,7 +179,7 @@ export default function SearchPage() {
                       <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow">
                         <div className="relative">
                           <Image
-                            src={scooter.image}
+                            src={scooter.images[0]}
                             alt={`${scooter.make} ${scooter.model}`}
                             width={400}
                             height={300}
@@ -309,7 +203,7 @@ export default function SearchPage() {
                               </h3>
                               <p className="text-sm text-gray-600">{scooter.location}</p>
                               <p className="text-sm text-gray-500">
-                                {scooter.transmission} • {scooter.seats} seats • {scooter.fuel}
+                                {scooter.features.transmission} • {scooter.features.seats} seats • {scooter.features.fuel}
                               </p>
                             </div>
                           </div>

--- a/data/scooters.ts
+++ b/data/scooters.ts
@@ -1,0 +1,153 @@
+export interface Scooter {
+  id: string;
+  make: string;
+  model: string;
+  year: number;
+  price: number;
+  rating: number;
+  reviews: number;
+  trips: number;
+  location: string;
+  images: string[];
+  features: {
+    seats: number;
+    transmission: string;
+    fuel: string;
+    weightCapacity: number;
+    batteryType: string;
+    range: number;
+    category: string;
+  };
+  host: {
+    name: string;
+    avatar: string;
+    rating: number;
+    trips: number;
+    responseTime: string;
+  };
+  description: string;
+  guidelines: string[];
+  extras: Array<{ name: string; price: number; included: boolean }>;
+}
+
+export const scooters: Scooter[] = [
+  {
+    id: '1',
+    make: 'Vespa',
+    model: 'Primavera',
+    year: 2023,
+    price: 89,
+    rating: 4.9,
+    reviews: 127,
+    trips: 312,
+    location: 'San Francisco, CA',
+    images: ['/api/placeholder/800/600', '/api/placeholder/800/600', '/api/placeholder/800/600'],
+    features: {
+      seats: 1,
+      transmission: 'Automatic',
+      fuel: 'Electric',
+      weightCapacity: 300,
+      batteryType: 'Lithium-Ion',
+      range: 50,
+      category: 'Standard'
+    },
+    host: {
+      name: 'Alex Chen',
+      avatar: '/api/placeholder/48/48',
+      rating: 4.9,
+      trips: 312,
+      responseTime: 'within an hour'
+    },
+    description:
+      'Experience the freedom of urban mobility with this pristine Vespa Primavera. Perfect for city commuting and exploring with exceptional battery range and performance.',
+    guidelines: [
+      'No smoking or pets allowed',
+      'Return with at least 50% battery',
+      'Treat the scooter with care as if it were your own'
+    ],
+    extras: [
+      { name: 'Prepaid charging', price: 15, included: false },
+      { name: 'Helmet rental', price: 10, included: false },
+      { name: 'Premium cleaning', price: 20, included: false }
+    ]
+  },
+  {
+    id: '2',
+    make: 'Honda',
+    model: 'PCX',
+    year: 2022,
+    price: 120,
+    rating: 4.8,
+    reviews: 89,
+    trips: 156,
+    location: 'Los Angeles, CA',
+    images: ['/api/placeholder/800/600', '/api/placeholder/800/600', '/api/placeholder/800/600'],
+    features: {
+      seats: 1,
+      transmission: 'Automatic',
+      fuel: 'Gasoline',
+      weightCapacity: 350,
+      batteryType: 'Lead-Acid',
+      range: 45,
+      category: 'Performance'
+    },
+    host: {
+      name: 'Sarah Miller',
+      avatar: '/api/placeholder/48/48',
+      rating: 4.8,
+      trips: 156,
+      responseTime: 'within a few hours'
+    },
+    description:
+      'Reliable Honda PCX ready for your next adventure. Smooth ride with great fuel efficiency and storage space.',
+    guidelines: [
+      'No off-road use',
+      'Return with full tank',
+      'Report any damage immediately'
+    ],
+    extras: [
+      { name: 'GPS Mount', price: 8, included: false },
+      { name: 'Phone holder', price: 5, included: true },
+      { name: 'Extra battery pack', price: 25, included: false }
+    ]
+  },
+  {
+    id: '3',
+    make: 'Yamaha',
+    model: 'AeroX',
+    year: 2021,
+    price: 45,
+    rating: 4.7,
+    reviews: 65,
+    trips: 89,
+    location: 'New York, NY',
+    images: ['/api/placeholder/800/600', '/api/placeholder/800/600', '/api/placeholder/800/600'],
+    features: {
+      seats: 1,
+      transmission: 'Automatic',
+      fuel: 'Gasoline',
+      weightCapacity: 320,
+      batteryType: 'Lithium-Ion',
+      range: 60,
+      category: 'Economy'
+    },
+    host: {
+      name: 'Mike Johnson',
+      avatar: '/api/placeholder/48/48',
+      rating: 4.7,
+      trips: 89,
+      responseTime: 'within a day'
+    },
+    description:
+      'Efficient Yamaha AeroX, perfect for navigating city streets with ease and style.',
+    guidelines: [
+      'Return on time',
+      'No racing or stunts',
+      'Keep it clean'
+    ],
+    extras: [
+      { name: 'Delivery to location', price: 30, included: false },
+      { name: 'Rain poncho', price: 7, included: false }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- centralize scooter data and expose a scooter detail API
- pull featured scooters from the API with a new "How Scoovio works" section on the landing page
- fetch scooter listings and detail pages dynamically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688d548a2ce48322af54bf489ca7e303